### PR TITLE
Add support for listing active users

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '23.0.0'
+__version__ = '23.1.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -390,6 +390,7 @@ class DataAPIClient(BaseAPIClient):
         personal_data_removed=None,
         *,
         user_research_opted_in=None,
+        active=None,
     ):
         warnings.warn(
             "The output of 'find_users' is paginated. Use 'find_users_iter' instead.",
@@ -410,6 +411,8 @@ class DataAPIClient(BaseAPIClient):
             params['personal_data_removed'] = personal_data_removed
         if user_research_opted_in is not None:
             params['user_research_opted_in'] = user_research_opted_in
+        if active is not None:
+            params['active'] = active
         return self._get("/users", params=params)
 
     find_users_iter = make_iter_method('find_users', 'users')

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -208,7 +208,7 @@ class TestUserMethods(object):
             'email_address': 'email_address',
             'name': 'name',
             'role': 'supplier',
-            'active': 'active',
+            'active': True,
             'locked': False,
             'created_at': "2015-05-05T05:05:05",
             'updated_at': "2015-05-05T05:05:05",
@@ -294,6 +294,28 @@ class TestUserMethods(object):
             json=user,
             status_code=200)
         user = data_client.find_users(user_research_opted_in=True)
+
+        assert user == expected_data
+
+    def test_find_users_by_active_false(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?active=false",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(active=False)
+
+        assert user == self.user()
+
+    def test_find_users_by_active_true(self, data_client, rmock):
+        user = self.user()
+        user['users'].update({'active': True})
+        expected_data = user.copy()
+
+        rmock.get(
+            "http://baseurl/users?active=true",
+            json=user,
+            status_code=200)
+        user = data_client.find_users(active=True)
 
         assert user == expected_data
 


### PR DESCRIPTION
It's something we often do in scripts. I've just added support for it in the API (https://github.com/Crown-Commercial-Service/digitalmarketplace-api/pull/1191).

And update tests accordingly