### PR TITLE
Add a new method to the api client to allow it to undo the countersigning

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '23.1.2'
+__version__ = '23.2.0'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1064,6 +1064,13 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def update_framework_agreement_undo_countersign(self, framework_agreement_id, user=None):
+        return self._post_with_updated_by(
+            "/agreements/{}/undo-countersign".format(framework_agreement_id),
+            data={},
+            user=user,
+        )
+
     def sign_framework_agreement(self, framework_agreement_id, user, signed_agreement_details=None):
         data = {"agreement": {"signedAgreementDetails": signed_agreement_details}} if signed_agreement_details else {}
         return self._post_with_updated_by(

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -2386,6 +2386,19 @@ class TestFrameworkAgreementMethods(object):
             "updated_by": "user@example.com",
         }
 
+    def test_update_framework_agreement_undo_countersign(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/agreements/12345/undo-countersign",
+            json={},
+            status_code=200)
+
+        result = data_client.update_framework_agreement_undo_countersign(12345, "user@example.com")
+
+        assert result == {}
+        assert rmock.last_request.json() == {
+            "updated_by": "user@example.com",
+        }
+
     def test_sign_framework_agreement_with_no_signed_agreement_details(self, data_client, rmock):
         rmock.post(
             "http://baseurl/agreements/12345/sign",


### PR DESCRIPTION
Add a new method to the api client to allow it to undo the countersigning of the framework agreement. This should only need to be used once and then we may consider removing it.

I have added tests for this new method.